### PR TITLE
Improve alphabet popup layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,18 +6,23 @@ let activeInput = null;
 
 function createPopup() {
     const popup = document.getElementById('alphabet-popup');
-    'abcdefghijklmnopqrstuvwxyz'.split('').forEach(ch => {
-        const div = document.createElement('div');
-        div.className = 'popup-letter';
-        div.textContent = ch.toUpperCase();
-        div.addEventListener('click', () => {
-            if (activeInput) {
-                activeInput.value = ch;
-                activeInput.dispatchEvent(new Event('input'));
-            }
-            hidePopup();
+    KEYBOARD_ROWS.forEach(row => {
+        const rowDiv = document.createElement('div');
+        rowDiv.className = 'popup-row';
+        row.split('').forEach(ch => {
+            const div = document.createElement('div');
+            div.className = 'popup-letter';
+            div.textContent = ch.toUpperCase();
+            div.addEventListener('click', () => {
+                if (activeInput) {
+                    activeInput.value = ch;
+                    activeInput.dispatchEvent(new Event('input'));
+                }
+                hidePopup();
+            });
+            rowDiv.appendChild(div);
         });
-        popup.appendChild(div);
+        popup.appendChild(rowDiv);
     });
     document.addEventListener('click', (e) => {
         if (!popup.contains(e.target) && !e.target.classList.contains('position-tile')) {
@@ -32,7 +37,7 @@ function showPopup(input) {
     const rect = input.getBoundingClientRect();
     popup.style.left = rect.left + window.scrollX + 'px';
     popup.style.top = rect.bottom + window.scrollY + 5 + 'px';
-    popup.style.display = 'grid';
+    popup.style.display = 'flex';
 }
 
 function hidePopup() {

--- a/style.css
+++ b/style.css
@@ -61,16 +61,24 @@ body {
     background-color: #f88;
 }
 
+
 .alphabet-popup {
     position: absolute;
     display: none;
-    grid-template-columns: repeat(10, 30px);
+    flex-direction: column;
     gap: 4px;
     padding: 6px;
     background: #fff;
     border: 1px solid #ccc;
     box-shadow: 0 2px 6px rgba(0,0,0,0.2);
     z-index: 100;
+    width: fit-content;
+}
+
+.popup-row {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
 }
 
 .alphabet-popup .popup-letter {


### PR DESCRIPTION
## Summary
- lay out the popup letters in QWERTY order
- display popup as flex rows styled like the main grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68426738878c83248448e1ce1355c082