### PR TITLE
Fix clear action preserving letter presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A simple single-page application to help filter Wordle words.
 
 ## Usage
 
-Open `index.html` in a browser. Use the alphabet grid to mark letters as present or absent by clicking each tile. Enter any known letters in each position. If you need to remove a letter, click the input and choose **Clear** from the popup. The page displays how many words from the list loaded from `words.txt` match your criteria.
+Open `index.html` in a browser. Use the alphabet grid to mark letters as present or absent by clicking each tile. Enter any known letters in each position. If you need to remove a letter, click the input and choose **Clear** from the popup. Using Clear empties the position without changing the letter's present/absent state. The page displays how many words from the list loaded from `words.txt` match your criteria.

--- a/script.js
+++ b/script.js
@@ -30,7 +30,9 @@ function createPopup() {
     clearDiv.addEventListener('click', () => {
         if (activeInput) {
             activeInput.value = '';
+            activeInput.dataset.keepPresent = 'true';
             activeInput.dispatchEvent(new Event('input'));
+            delete activeInput.dataset.keepPresent;
         }
         hidePopup();
     });
@@ -101,6 +103,7 @@ function cycleState(letter) {
 
 function handlePositionInput(e) {
     const input = e.target;
+    const keepPresent = input.dataset.keepPresent === 'true';
     let val = input.value.toLowerCase().replace(/[^a-z]/g, '');
     if (val.length > 1) val = val[0];
     if (val && letterStates[val] === 'absent') {
@@ -109,7 +112,7 @@ function handlePositionInput(e) {
     const prev = input.dataset.prev || '';
     if (prev && prev !== val) {
         const stillUsed = Array.from(document.querySelectorAll('#position-row input')).some(el => el !== input && el.value.toLowerCase() === prev);
-        if (!stillUsed && letterStates[prev] === 'present') {
+        if (!stillUsed && letterStates[prev] === 'present' && !keepPresent) {
             setState(prev, 'unknown');
         }
     }


### PR DESCRIPTION
## Summary
- allow clearing a position without clearing `present` state
- document the new behaviour

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6842d2b5bcd083249f3492413d088521