### PR TITLE
Reset inputs on page reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@
     <h1>Wordle Helper</h1>
     <div id="letter-grid" class="letter-grid"></div>
     <div id="position-row" class="position-row">
-        <input class="position-tile" type="text" id="pos0" maxlength="1" />
-        <input class="position-tile" type="text" id="pos1" maxlength="1" />
-        <input class="position-tile" type="text" id="pos2" maxlength="1" />
-        <input class="position-tile" type="text" id="pos3" maxlength="1" />
-        <input class="position-tile" type="text" id="pos4" maxlength="1" />
+        <input class="position-tile" type="text" id="pos0" maxlength="1" autocomplete="off" />
+        <input class="position-tile" type="text" id="pos1" maxlength="1" autocomplete="off" />
+        <input class="position-tile" type="text" id="pos2" maxlength="1" autocomplete="off" />
+        <input class="position-tile" type="text" id="pos3" maxlength="1" autocomplete="off" />
+        <input class="position-tile" type="text" id="pos4" maxlength="1" autocomplete="off" />
     </div>
     <div id="alphabet-popup" class="alphabet-popup"></div>
     <details id="word-list-container" class="word-list-container">

--- a/script.js
+++ b/script.js
@@ -186,9 +186,10 @@ document.addEventListener('DOMContentLoaded', () => {
     createGrid();
     createPopup();
     document.querySelectorAll('#position-row input').forEach(input => {
+        input.value = '';
+        input.dataset.prev = '';
         input.addEventListener('input', handlePositionInput);
         input.addEventListener('click', () => showPopup(input));
-        input.dataset.prev = '';
     });
     loadWords();
 });


### PR DESCRIPTION
## Summary
- turn off autocomplete on the five known position inputs
- clear the known position fields when the page loads so refreshes don't keep values

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842dabacd648324a5b2393c066db5f9