### PR TITLE
Enable PR previews on GitHub Pages

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,45 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+
+env:
+  DEST_DIR: pr-${{ github.event.pull_request.number }}
+
+jobs:
+  deploy:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Deploy preview
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: .
+          destination_dir: ${{ env.DEST_DIR }}
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Remove preview directory
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          rm -rf $DEST_DIR
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}"
+            git push origin gh-pages
+          fi

--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ A simple single-page application to help filter Wordle words.
 ## Usage
 
 Open `index.html` in a browser. Use the alphabet grid to mark letters as present or absent by clicking each tile. Enter any known letters in each position. If you need to remove a letter, click the input and choose **Clear** from the popup. Using Clear empties the position without changing the letter's present/absent state. The page displays how many words from the list loaded from `words.txt` match your criteria.
+
+## Pull Request Previews
+
+Open pull requests automatically deploy to a subfolder on the `gh-pages` branch.
+A PR with number `123` will be available at:
+
+```
+https://<your-user>.github.io/wordle-helper/pr-123/
+```
+


### PR DESCRIPTION
## Summary
- document PR preview links
- add workflow to publish preview builds to gh-pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842ef75fb2c83248ff31387e26b5d7c