### PR TITLE
Add letter count controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <h1>Wordle Helper</h1>
+    <p>Use the tiny number boxes to note how many times a letter appears.</p>
     <div id="letter-grid" class="letter-grid"></div>
     <div id="position-row" class="position-row">
         <input class="position-tile" type="text" id="pos0" maxlength="1" autocomplete="off" />

--- a/style.css
+++ b/style.css
@@ -46,6 +46,20 @@ body {
     justify-content: center;
 }
 
+.tile-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 2px;
+}
+
+.count-input {
+    width: 28px;
+    height: 20px;
+    font-size: 12px;
+    text-align: center;
+}
+
 .letter-grid .tile {
     width: 28px;
     height: 28px;


### PR DESCRIPTION
## Summary
- support specifying exact letter counts
- show number inputs below each keyboard tile
- update filtering logic to respect counts

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6844776445008324b92ae0c379c4153f