### PR TITLE
Add step attribute for letter count inputs

### DIFF
--- a/script.js
+++ b/script.js
@@ -86,6 +86,7 @@ function createGrid() {
             input.type = 'number';
             input.min = '0';
             input.max = '5';
+            input.step = '1';
             input.value = '0';
             input.className = 'count-input';
             input.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- enable numeric stepper by specifying `step="1"` for letter count inputs

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844840327a883248c8bd62c0b025b36