### PR TITLE
Fix clearing position inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A simple single-page application to help filter Wordle words.
 
 ## Usage
 
-Open `index.html` in a browser. Use the alphabet grid to mark letters as present or absent by clicking each tile. Enter any known letters in each position. If you need to remove a letter, click the input and choose **Clear** from the popup. Using Clear empties the position without changing the letter's present/absent state. The page displays how many words from the list loaded from `words.txt` match your criteria.
+Open `index.html` in a browser. Use the alphabet grid to mark letters as present or absent by clicking each tile. Enter any known letters in each position. If you need to remove a letter, click the input and choose **Clear** from the popup, or simply erase the letter. Either method now keeps the letter marked present if you had already set it that way. The page displays how many words from the list loaded from `words.txt` match your criteria.

--- a/script.js
+++ b/script.js
@@ -147,13 +147,20 @@ function handlePositionInput(e) {
     const prev = input.dataset.prev || '';
     if (prev && prev !== val) {
         const stillUsed = Array.from(document.querySelectorAll('#position-row input')).some(el => el !== input && el.value.toLowerCase() === prev);
-        if (!stillUsed && letterStates[prev] === 'present' && !keepPresent) {
+        if (!stillUsed && input.dataset.addedPresent === prev && !keepPresent) {
             setState(prev, 'unknown');
         }
+        input.dataset.addedPresent = '';
     }
     input.value = val;
     input.dataset.prev = val;
     if (val) {
+        const usedElsewhere = Array.from(document.querySelectorAll('#position-row input')).some(el => el !== input && el.value.toLowerCase() === val);
+        if (letterStates[val] === 'unknown' && !usedElsewhere && letterCounts[val] === 0) {
+            input.dataset.addedPresent = val;
+        } else {
+            input.dataset.addedPresent = '';
+        }
         setState(val, 'present');
     }
     filterWords();
@@ -219,6 +226,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('#position-row input').forEach(input => {
         input.value = '';
         input.dataset.prev = '';
+        input.dataset.addedPresent = '';
         input.addEventListener('input', handlePositionInput);
         input.addEventListener('click', () => showPopup(input));
     });


### PR DESCRIPTION
## Summary
- don't revert known letters to `unknown` when a position input is cleared
- mention that erasing a letter keeps its state in the docs

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684c0d1343348324988743723241fc3e