### PR TITLE
Add per-tab persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ A simple single-page application to help filter Wordle words.
 ## Usage
 
 Open `index.html` in a browser. Use the alphabet grid to mark letters as present or absent by clicking each tile. Enter any known letters in each position. If you need to remove a letter, click the input and choose **Clear** from the popup, or simply erase the letter. Either method now keeps the letter marked present if you had already set it that way. The page displays how many words from the list loaded from `words.txt` match your criteria.
+
+Your selections persist in local storage for the lifetime of each tab's session. Every tab gets its own save slot, so you can keep multiple helpers open at once and return to them even after your device naps.


### PR DESCRIPTION
## Summary
- store state under a unique session id
- recover the session id on load via sessionStorage
- update the docs about per-tab saves

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_684c6217c2d48324a159eab186453566