### PR TITLE
Add diagnostic logging for session

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ A simple single-page application to help filter Wordle words.
 Open `index.html` in a browser. Use the alphabet grid to mark letters as present or absent by clicking each tile. Enter any known letters in each position. If you need to remove a letter, click the input and choose **Clear** from the popup, or simply erase the letter. Either method now keeps the letter marked present if you had already set it that way. The page displays how many words from the list loaded from `words.txt` match your criteria.
 
 Your selections persist in local storage for the lifetime of each tab's session. Every tab gets its own save slot, so you can keep multiple helpers open at once and return to them even after your device naps.
+
+A small diagnostics line at the bottom of the page shows when the session began and when the page last loaded.

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         <summary id="result">0 possible words</summary>
         <ul id="word-list" class="word-list"></ul>
     </details>
+    <div id="diagnostic-info" class="diagnostic-info"></div>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ const popupLetterElements = {};
 const countInputElements = {};
 let sessionId = null;
 let activeInput = null;
+let pageLoadTime = null;
 
 function createPopup() {
     const popup = document.getElementById('alphabet-popup');
@@ -69,6 +70,9 @@ function getSessionId() {
     if (!id) {
         id = Date.now().toString(36) + Math.random().toString(36).slice(2);
         sessionStorage.setItem('wordleHelperSession', id);
+        const initTime = new Date().toISOString();
+        sessionStorage.setItem('wordleHelperInitTime', initTime);
+        console.log('Session initialized at', initTime);
     }
     return id;
 }
@@ -292,8 +296,17 @@ async function loadWords() {
     filterWords();
 }
 
+function updateDiagnostics() {
+    const infoEl = document.getElementById('diagnostic-info');
+    if (!infoEl) return;
+    const initTime = sessionStorage.getItem('wordleHelperInitTime');
+    infoEl.textContent = `Session init: ${initTime} | Page loaded: ${pageLoadTime} | Current: ${new Date().toISOString()}`;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     sessionId = getSessionId();
+    pageLoadTime = new Date().toISOString();
+    console.log('Page loaded at', pageLoadTime);
     createGrid();
     createPopup();
     document.querySelectorAll('#position-row input').forEach(input => {
@@ -304,4 +317,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     loadState();
     loadWords();
+    updateDiagnostics();
+    setInterval(updateDiagnostics, 60000);
 });

--- a/style.css
+++ b/style.css
@@ -142,3 +142,9 @@ body {
     max-height: 200px;
     overflow-y: auto;
 }
+
+.diagnostic-info {
+    margin-top: 10px;
+    font-size: 12px;
+    color: #555;
+}


### PR DESCRIPTION
## Summary
- track session creation time
- log when session storage is initialized and when page loads
- display session timestamps at the bottom of the page
- tweak styling for the new info

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684dc7cb78b88324a4f43bafb4f9ec9a