### PR TITLE
Add basic Playwright tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+playwright-report/
+test-results/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "wordle-helper",
+  "version": "1.0.0",
+  "description": "A simple single-page application to help filter Wordle words.",
+  "main": "script.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "playwright": "^1.53.1"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  testDir: './tests',
+  webServer: {
+    command: 'node server.js',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+};

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const baseDir = __dirname;
+
+const server = http.createServer((req, res) => {
+  let reqPath = req.url.split('?')[0];
+  if (reqPath === '/') reqPath = '/index.html';
+  const filePath = path.join(baseDir, reqPath);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath);
+    const type = {
+      '.html': 'text/html',
+      '.css': 'text/css',
+      '.js': 'application/javascript',
+      '.txt': 'text/plain'
+    }[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => console.log(`Server running on port ${port}`));

--- a/tests/basic.spec.js
+++ b/tests/basic.spec.js
@@ -1,0 +1,27 @@
+const { test, expect } = require('playwright/test');
+const fs = require('fs');
+
+const baseURL = 'http://localhost:3000';
+const words = fs.readFileSync('words.txt', 'utf-8')
+  .trim()
+  .split(/\r?\n/);
+
+function countWordsStartingWith(letter) {
+  return words.filter(w => w.startsWith(letter)).length;
+}
+
+test.describe('Wordle Helper', () => {
+  test('shows all words on first load', async ({ page }) => {
+    await page.goto(baseURL);
+    await expect(page.locator('#result')).toHaveText(`${words.length} possible words`);
+  });
+
+  test('filters by first letter', async ({ page }) => {
+    await page.goto(baseURL);
+    await page.fill('#pos0', 'a');
+    const expected = countWordsStartingWith('a');
+    await expect(page.locator('#result')).toHaveText(`${expected} possible words`);
+    const list = await page.$$eval('#word-list li', els => els.map(el => el.textContent));
+    expect(list.every(w => w.startsWith('a'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- configure Playwright with a simple static web server
- ignore node-related artifacts
- add tests checking initial word count and filtering

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861aeeb83e48324a12dee6b4a40a2fb