### PR TITLE
Add more Playwright tests

### DIFF
--- a/tests/basic.spec.js
+++ b/tests/basic.spec.js
@@ -24,4 +24,36 @@ test.describe('Wordle Helper', () => {
     const list = await page.$$eval('#word-list li', els => els.map(el => el.textContent));
     expect(list.every(w => w.startsWith('a'))).toBe(true);
   });
+
+  test('selects letter from popup', async ({ page }) => {
+    await page.goto(baseURL);
+    await page.click('#pos1');
+    await expect(page.locator('#alphabet-popup')).toBeVisible();
+    await page.click('#alphabet-popup .popup-letter:has-text("B")');
+    await expect(page.locator('#alphabet-popup')).toBeHidden();
+    await expect(page.locator('#pos1')).toHaveValue('b');
+    await expect(page.locator('.tile', { hasText: 'B' })).toHaveClass(/present/);
+  });
+
+  test('absent letters disabled in popup', async ({ page }) => {
+    await page.goto(baseURL);
+    const tile = page.locator('.tile', { hasText: 'C' });
+    await tile.click();
+    await tile.click();
+    await expect(tile).toHaveClass(/absent/);
+    await page.click('#pos2');
+    const popupLetter = page.locator('#alphabet-popup .popup-letter:has-text("C")');
+    await expect(popupLetter).toHaveClass(/disabled/);
+  });
+
+  test('typing count replaces value', async ({ page }) => {
+    await page.goto(baseURL);
+    const container = page.locator('.tile-container', { has: page.locator('.tile', { hasText: 'D' }) });
+    const input = container.locator('input');
+    await input.focus();
+    await input.type('1');
+    await expect(input).toHaveValue('1');
+    await input.type('3');
+    await expect(input).toHaveValue('3');
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for popup letter selection
- check absent letter disabled state
- verify count input digit replace behavior

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e687574883248fbb66f2b9e7f1a6