### PR TITLE
Add yellow state for position tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
     <p>Use the tiny number boxes to note how many times a letter appears.</p>
     <div id="letter-grid" class="letter-grid"></div>
     <div id="position-row" class="position-row">
-        <input class="position-tile" type="text" id="pos0" maxlength="1" autocomplete="off" />
-        <input class="position-tile" type="text" id="pos1" maxlength="1" autocomplete="off" />
-        <input class="position-tile" type="text" id="pos2" maxlength="1" autocomplete="off" />
-        <input class="position-tile" type="text" id="pos3" maxlength="1" autocomplete="off" />
-        <input class="position-tile" type="text" id="pos4" maxlength="1" autocomplete="off" />
+        <div class="position-tile" id="pos0"></div>
+        <div class="position-tile" id="pos1"></div>
+        <div class="position-tile" id="pos2"></div>
+        <div class="position-tile" id="pos3"></div>
+        <div class="position-tile" id="pos4"></div>
     </div>
     <div id="alphabet-popup" class="alphabet-popup"></div>
     <details id="word-list-container" class="word-list-container">

--- a/style.css
+++ b/style.css
@@ -30,6 +30,10 @@ body {
     cursor: pointer;
 }
 
+.position-tile.not-here {
+    background-color: #ffea70;
+}
+
 .position-tile:focus {
     outline: none;
 }

--- a/tests/basic.spec.js
+++ b/tests/basic.spec.js
@@ -18,7 +18,8 @@ test.describe('Wordle Helper', () => {
 
   test('filters by first letter', async ({ page }) => {
     await page.goto(baseURL);
-    await page.fill('#pos0', 'a');
+    await page.click('#pos0');
+    await page.click('#alphabet-popup .popup-letter:has-text("A")');
     const expected = countWordsStartingWith('a');
     await expect(page.locator('#result')).toHaveText(`${expected} possible words`);
     const list = await page.$$eval('#word-list li', els => els.map(el => el.textContent));
@@ -31,7 +32,7 @@ test.describe('Wordle Helper', () => {
     await expect(page.locator('#alphabet-popup')).toBeVisible();
     await page.click('#alphabet-popup .popup-letter:has-text("B")');
     await expect(page.locator('#alphabet-popup')).toBeHidden();
-    await expect(page.locator('#pos1')).toHaveValue('b');
+    await expect(page.locator('#pos1')).toHaveText('B');
     await expect(page.locator('.tile', { hasText: 'B' })).toHaveClass(/present/);
   });
 
@@ -59,12 +60,13 @@ test.describe('Wordle Helper', () => {
 
   test('clearing position resets auto-added present', async ({ page }) => {
     await page.goto(baseURL);
-    await page.fill('#pos3', 'e');
+    await page.click('#pos3');
+    await page.click('#alphabet-popup .popup-letter:has-text("E")');
     const tile = page.locator('.tile', { hasText: 'E' });
     await expect(tile).toHaveClass(/present/);
     await page.click('#pos3');
-    await page.click('#alphabet-popup .popup-clear');
-    await expect(page.locator('#pos3')).toHaveValue('');
+    await page.click('#pos3');
+    await expect(page.locator('#pos3')).toHaveText('');
     await expect(tile).not.toHaveClass(/present/);
   });
 });


### PR DESCRIPTION
## Summary
- switch position inputs to clickable tiles
- add `not-here` yellow state for positions
- update filtering logic for new state
- adjust tests for new interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873a35761188324a83568649b257437